### PR TITLE
Fix RPC defaults and Jupiter price endpoints

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,9 +1,11 @@
 # Run in context of one realm: starts with default realm and disables realms page navigation
 # REALM=MNGO
-NEXT_PUBLIC_MAINNET_RPC=https://api.mainnet-beta.solana.com
+# NEXT_PUBLIC_MAINNET_RPC=https://api.mainnet-beta.solana.com
+NEXT_PUBLIC_MAINNET_RPC=https://correct-enrichetta-fast-mainnet.helius-rpc.com
 NEXT_PUBLIC_DEVNET_RPC=https://api.devnet.solana.com
 MAINNET_RPC=https://api.mainnet-beta.solana.com
 DEVNET_RPC=https://api.devnet.solana.com
+JUPITER_API_KEY=
 
 DEFAULT_GOVERNANCE_PROGRAM_ID=GTesTBiEWE32WHXXE2S4XbZvA5CrEc4xs6ZgRe895dP
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,9 @@
 # Run in context of one realm: starts with default realm and disables realms page navigation
 # REALM=MNGO
-MAINNET_RPC=https://mango.rpcpool.com
-DEVNET_RPC=https://mango.devnet.rpcpool.com
+NEXT_PUBLIC_MAINNET_RPC=https://api.mainnet-beta.solana.com
+NEXT_PUBLIC_DEVNET_RPC=https://api.devnet.solana.com
+MAINNET_RPC=https://api.mainnet-beta.solana.com
+DEVNET_RPC=https://api.devnet.solana.com
 
 DEFAULT_GOVERNANCE_PROGRAM_ID=GTesTBiEWE32WHXXE2S4XbZvA5CrEc4xs6ZgRe895dP
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,17 +1,17 @@
 # Run in context of one realm: starts with default realm and disables realms page navigation
 # REALM=MNGO
-# NEXT_PUBLIC_MAINNET_RPC=https://api.mainnet-beta.solana.com
-NEXT_PUBLIC_MAINNET_RPC=https://correct-enrichetta-fast-mainnet.helius-rpc.com
+# NEXT_PUBLIC_MAINNET_RPC is no longer used for mainnet HTTP requests.
+NEXT_PUBLIC_MAINNET_RPC=
 NEXT_PUBLIC_DEVNET_RPC=https://api.devnet.solana.com
-MAINNET_RPC=https://api.mainnet-beta.solana.com
+MAINNET_RPC=
 DEVNET_RPC=https://api.devnet.solana.com
 JUPITER_API_KEY=
+JUPITER_SWAP_API_BASE_URL=https://api.jup.ag
+HELIUS_MAINNET_RPC=
+HELIUS_DEVNET_RPC=
 
 DEFAULT_GOVERNANCE_PROGRAM_ID=GTesTBiEWE32WHXXE2S4XbZvA5CrEc4xs6ZgRe895dP
 
-NEXT_PUBLIC_JUPTER_SWAP_API_ENDPOINT=https://quote-api.jup.ag/v6
 NEXT_PUBLIC_API_ENDPOINT=https://api.realms.today/graphql
 NEXT_PUBLIC_DISCORD_APPLICATION_CLIENT_ID=1042836142560645130
 NEXT_PUBLIC_DISCORD_MATCHDAY_CLIENT_ID=1044361939322683442
-NEXT_PUBLIC_HELIUS_MAINNET_RPC=
-NEXT_PUBLIC_HELIUS_DEVNET_RPC=

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Using custom Swap API endpoints
 
-You can set custom URLs via the configuration for any self-hosted Jupiter APIs, like the [V6 Swap API](https://station.jup.ag/docs/apis/self-hosted) or [Paid Hosted APIs](https://station.jup.ag/docs/apis/self-hosted#paid-hosted-apis) Here is an example:
+Jupiter swap requests are proxied through the app server so API keys stay private. If you need a custom self-hosted or paid Jupiter base URL, configure it with a server-side env var:
 
 ```
-NEXT_PUBLIC_JUPTER_SWAP_API_ENDPOINT=https://quote-api.jup.ag/v6
+JUPITER_SWAP_API_BASE_URL=https://api.jup.ag
 ```

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -29,7 +29,12 @@ import {
   WalletProvider,
 } from '@solana/wallet-adapter-react'
 import useLegacyConnectionContext from '@hooks/useLegacyConnectionContext'
-import { DEVNET_RPC, MAINNET_RPC } from 'constants/endpoints'
+import {
+  DEVNET_RPC,
+  DEVNET_WS_RPC,
+  MAINNET_RPC,
+  MAINNET_WS_RPC,
+} from 'constants/endpoints'
 import {
   SquadsEmbeddedWalletAdapter,
   detectEmbeddedInSquadsIframe,
@@ -79,6 +84,10 @@ export function App(props: Props) {
     () => (cluster === 'devnet' ? DEVNET_RPC : MAINNET_RPC),
     [cluster],
   )
+  const wsEndpoint = useMemo(
+    () => (cluster === 'devnet' ? DEVNET_WS_RPC : MAINNET_WS_RPC),
+    [cluster],
+  )
 
   const supportedWallets = useMemo(
     () =>
@@ -89,7 +98,7 @@ export function App(props: Props) {
   )
 
   return (
-    <ConnectionProvider endpoint={endpoint}>
+    <ConnectionProvider endpoint={endpoint} config={{ wsEndpoint }}>
       <WalletProvider wallets={supportedWallets}>
         <AppContents {...props} />{' '}
       </WalletProvider>

--- a/constants/endpoints.ts
+++ b/constants/endpoints.ts
@@ -1,9 +1,7 @@
-export const MAINNET_RPC =
-  process.env.NEXT_PUBLIC_MAINNET_RPC ||
-  process.env.MAINNET_RPC ||
-  'https://api.mainnet-beta.solana.com'
+import { getSolanaRpcEndpoint, getSolanaWsEndpoint } from '@utils/solanaRpc'
 
-export const DEVNET_RPC =
-  process.env.NEXT_PUBLIC_DEVNET_RPC ||
-  process.env.DEVNET_RPC ||
-  'https://api.devnet.solana.com'
+export const MAINNET_RPC = getSolanaRpcEndpoint('mainnet')
+export const DEVNET_RPC = getSolanaRpcEndpoint('devnet')
+
+export const MAINNET_WS_RPC = getSolanaWsEndpoint('mainnet')
+export const DEVNET_WS_RPC = getSolanaWsEndpoint('devnet')

--- a/constants/endpoints.ts
+++ b/constants/endpoints.ts
@@ -1,9 +1,9 @@
 export const MAINNET_RPC =
   process.env.NEXT_PUBLIC_MAINNET_RPC ||
-  process.env.MAINNET_RPC || 'https://mainnet.helius-rpc.com/?api-key=2aca1e9b-9f51-44a0-938b-89dc6c23e9b4'
-//  'http://realms-realms-c335.mainnet.rpcpool.com'
+  process.env.MAINNET_RPC ||
+  'https://api.mainnet-beta.solana.com'
 
 export const DEVNET_RPC =
   process.env.NEXT_PUBLIC_DEVNET_RPC ||
-  process.env.DEVNET_RPC || 'https://devnet.helius-rpc.com/?api-key=2aca1e9b-9f51-44a0-938b-89dc6c23e9b4'
-//  'https://mango.devnet.rpcpool.com'
+  process.env.DEVNET_RPC ||
+  'https://api.devnet.solana.com'

--- a/hooks/queries/digitalAssets.ts
+++ b/hooks/queries/digitalAssets.ts
@@ -6,25 +6,13 @@ import { useConnection } from '@solana/wallet-adapter-react'
 import { getNativeTreasuryAddress } from '@solana/spl-governance'
 import queryClient from './queryClient'
 import { getNetworkFromEndpoint } from '@utils/connection'
+import { getHeliusProxyPath, HeliusNetwork } from '@utils/heliusApi'
 import axios from 'axios'
 import { BN } from '@coral-xyz/anchor'
 
 type Network = 'devnet' | 'mainnet'
-const getHeliusEndpoint = (network: Network) => {
-  const url =
-    network === 'devnet'
-      ? process.env.NEXT_PUBLIC_HELIUS_DEVNET_RPC
-      : process.env.NEXT_PUBLIC_HELIUS_MAINNET_RPC
-  if (url === undefined)
-    throw new Error(
-      `Helius RPC endpoint not set in env: ${
-        network === 'devnet'
-          ? 'NEXT_PUBLIC_HELIUS_DEVNET_RPC'
-          : 'NEXT_PUBLIC_HELIUS_MAINNET_RPC'
-      }`,
-    )
-  return url
-}
+const getHeliusEndpoint = (network: Network) =>
+  getHeliusProxyPath(network as HeliusNetwork)
 
 export const digitalAssetsQueryKeys = {
   all: (network: Network) => [network, 'DigitalAssets'], // TBH endpoint is stupid for this. it should be either 'devnet' or 'mainnet'.

--- a/hooks/queries/jupiterPrice.ts
+++ b/hooks/queries/jupiterPrice.ts
@@ -1,12 +1,11 @@
 import { PublicKey } from '@solana/web3.js'
 import { useQuery } from '@tanstack/react-query'
+import { JUPITER_PRICE_BATCH_LIMIT, fetchJupiterPriceJson } from '@utils/jupiterApi'
 import queryClient from './queryClient'
-
-const URL = 'https://lite-api.jup.ag/price/v3'
 
 /* example query
 # Unit price of 1 JUP & 1 SOL based on the Derived Price in USDC
-https://lite-api.jup.ag/price/v3?ids=JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN,So11111111111111111111111111111111111111112
+https://api.jup.ag/price/v3?ids=JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN,So11111111111111111111111111111111111111112
 
 {
     "So11111111111111111111111111111111111111112": {
@@ -39,8 +38,14 @@ type V3Price = {
 
 type V3Response = Record<string, V3Price | null | undefined>
 
-const normalizePriceResponse = (response: Response | V3Response) => {
-  if ('data' in response) {
+const isLegacyResponse = (
+  response: Response | V3Response,
+): response is Response => 'data' in response && 'timeTaken' in response
+
+const normalizePriceResponse = (
+  response: Response | V3Response,
+): Response['data'] => {
+  if (isLegacyResponse(response)) {
     return response.data
   }
 
@@ -56,7 +61,7 @@ const normalizePriceResponse = (response: Response | V3Response) => {
           price: Number(data?.usdPrice ?? data?.price),
         },
       ]),
-  )
+  ) as Response['data']
 }
 
 function* chunks<T>(arr: T[], n: number): Generator<T[], void> {
@@ -74,10 +79,17 @@ export const jupiterPriceQueryKeys = {
   ],
 }
 
+const fetchJupiterPriceBatch = async (
+  mints: string[],
+): Promise<Response['data']> => {
+  const response = await fetchJupiterPriceJson<Response | V3Response>(mints)
+  return normalizePriceResponse(response)
+}
+
 const jupQueryFn = async (mint: PublicKey) => {
-  const x = await fetch(`${URL}?ids=${mint?.toString()}`)
-  const response = (await x.json()) as Response | V3Response
-  const result = normalizePriceResponse(response)[mint.toString()]
+  const result = (await fetchJupiterPriceBatch([mint.toString()]))[
+    mint.toString()
+  ]
   return result !== undefined
     ? ({ found: true, result } as const)
     : ({ found: false, result: undefined } as const)
@@ -117,13 +129,13 @@ export const useJupiterPricesByMintsQuery = (mints: PublicKey[]) => {
     enabled,
     queryKey: jupiterPriceQueryKeys.byMints(dedupedMints),
     queryFn: async () => {
-      const batches = [...chunks(dedupedMints, 100)]
+      const batches = [
+        ...chunks(dedupedMints, JUPITER_PRICE_BATCH_LIMIT),
+      ]
       const responses = await Promise.all(
-        batches.map(async (batch) => {
-          const x = await fetch(`${URL}?ids=${batch.join(',')}`)
-          const response = (await x.json()) as Response | V3Response
-          return normalizePriceResponse(response)
-        }),
+        batches.map((batch) =>
+          fetchJupiterPriceBatch(batch.map((mint) => mint.toString())),
+        ),
       )
       const data = responses.reduce(
         (acc, next) => ({ ...acc, ...next }),
@@ -156,18 +168,16 @@ export const useJupiterPricesByMintsQuery = (mints: PublicKey[]) => {
 }
 
 // function is used to get fresh token prices
-export const getJupiterPricesByMintStrings = async (mints: string[]) => {
+export const getJupiterPricesByMintStrings = async (
+  mints: string[],
+): Promise<Response['data']> => {
   if (mints.length === 0) return {}
   const deduped = new Set(mints)
   const dedupedMints = Array.from(deduped)
   try {
     const batches = [...chunks(dedupedMints, 50)]
     const responses = await Promise.all(
-      batches.map(async (batch) => {
-        const x = await fetch(`${URL}?ids=${batch.join(',')}`)
-        const response = (await x.json()) as Response | V3Response
-        return normalizePriceResponse(response)
-      }),
+      batches.map((batch) => fetchJupiterPriceBatch(batch)),
     )
     const data = responses.reduce(
       (acc, next) => ({ ...acc, ...next }),

--- a/hooks/queries/jupiterPrice.ts
+++ b/hooks/queries/jupiterPrice.ts
@@ -2,40 +2,19 @@ import { PublicKey } from '@solana/web3.js'
 import { useQuery } from '@tanstack/react-query'
 import queryClient from './queryClient'
 
-const URL = 'https://api.jup.ag/price/v2'
+const URL = 'https://lite-api.jup.ag/price/v3'
 
 /* example query
 # Unit price of 1 JUP & 1 SOL based on the Derived Price in USDC
-https://api.jup.ag/price/v2?ids=JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN,So11111111111111111111111111111111111111112
+https://lite-api.jup.ag/price/v3?ids=JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN,So11111111111111111111111111111111111111112
 
 {
-    "data": {
-        "So11111111111111111111111111111111111111112": {
-            "id": "So11111111111111111111111111111111111111112",
-            "type": "derivedPrice",
-            "price": "133.890945000"
-        },
-        "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN": {
-            "id": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
-            "type": "derivedPrice",
-            "price": "0.751467"
-        }
+    "So11111111111111111111111111111111111111112": {
+        "usdPrice": 133.890945000
     },
-    "timeTaken": 0.00395219
-}
-*/
-/* example intentionally broken query 
-curl -X 'GET' 'https://api.jup.ag/price/v2?ids=So11111111111111111111111111111111111111112&showExtraInfo=true'
-{
-    "data": {
-        "So11111111111111111111111111111111111111112": {
-            "id": "So11111111111111111111111111111111111111112",
-            "type": "derivedPrice",
-            "price": "134.170633378"
-        },
-        "8agCopCHWdpj7mHk3JUWrzt8pHAxMiPX5hLVDJh9TXWv": null
-    },
-    "timeTaken": 0.003186833
+    "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN": {
+        "usdPrice": 0.751467
+    }
 }
 */
 
@@ -51,6 +30,33 @@ type Price = {
 type Response = {
   data: Record<string, Price> //uses whatever you input (so, pubkey OR symbol). no entry if data not found
   timeTaken: number
+}
+
+type V3Price = {
+  usdPrice?: number
+  price?: number
+}
+
+type V3Response = Record<string, V3Price | null | undefined>
+
+const normalizePriceResponse = (response: Response | V3Response) => {
+  if ('data' in response) {
+    return response.data
+  }
+
+  return Object.fromEntries(
+    Object.entries(response)
+      .filter(
+        ([, data]) => data?.usdPrice !== undefined || data?.price !== undefined,
+      )
+      .map(([id, data]) => [
+        id,
+        {
+          id,
+          price: Number(data?.usdPrice ?? data?.price),
+        },
+      ]),
+  )
 }
 
 function* chunks<T>(arr: T[], n: number): Generator<T[], void> {
@@ -70,8 +76,8 @@ export const jupiterPriceQueryKeys = {
 
 const jupQueryFn = async (mint: PublicKey) => {
   const x = await fetch(`${URL}?ids=${mint?.toString()}`)
-  const response = (await x.json()) as Response
-  const result = response.data[mint.toString()]
+  const response = (await x.json()) as Response | V3Response
+  const result = normalizePriceResponse(response)[mint.toString()]
   return result !== undefined
     ? ({ found: true, result } as const)
     : ({ found: false, result: undefined } as const)
@@ -115,12 +121,12 @@ export const useJupiterPricesByMintsQuery = (mints: PublicKey[]) => {
       const responses = await Promise.all(
         batches.map(async (batch) => {
           const x = await fetch(`${URL}?ids=${batch.join(',')}`)
-          const response = (await x.json()) as Response
-          return response
+          const response = (await x.json()) as Response | V3Response
+          return normalizePriceResponse(response)
         }),
       )
       const data = responses.reduce(
-        (acc, next) => ({ ...acc, ...next.data }),
+        (acc, next) => ({ ...acc, ...next }),
         {} as Response['data'],
       )
 
@@ -155,9 +161,18 @@ export const getJupiterPricesByMintStrings = async (mints: string[]) => {
   const deduped = new Set(mints)
   const dedupedMints = Array.from(deduped)
   try {
-    const x = await fetch(`${URL}?ids=${dedupedMints.join(',')}`)
-    const response = (await x.json()) as Response
-    const data = response.data
+    const batches = [...chunks(dedupedMints, 50)]
+    const responses = await Promise.all(
+      batches.map(async (batch) => {
+        const x = await fetch(`${URL}?ids=${batch.join(',')}`)
+        const response = (await x.json()) as Response | V3Response
+        return normalizePriceResponse(response)
+      }),
+    )
+    const data = responses.reduce(
+      (acc, next) => ({ ...acc, ...next }),
+      {} as Response['data'],
+    )
 
     //override chai price if its broken
     const chaiMint = '3jsFX1tx2Z8ewmamiwSU851GzyzM2DJMq7KWW5DM8Py3'

--- a/hub/components/GlobalStats/Stats.tsx
+++ b/hub/components/GlobalStats/Stats.tsx
@@ -15,6 +15,7 @@ import { NumRealms } from './NumRealms';
 import { NumVoteRecords } from './NumVoteRecords';
 import { TotalValue } from './TotalValue';
 import { ValueByDao } from './ValueByDao';
+import { HELIUS_MAINNET_PROXY_PATH } from '@utils/heliusApi';
 
 interface Props {
   className?: string;
@@ -43,10 +44,19 @@ export function Stats(props: Props) {
   const [donefetchingNFTs, setDoneFetchingNFTs] = useState(false);
   const timer = useRef<number | null>(null);
   const wakePrevent = useRef<any>(null);
-  const connection = useRef(
-    new Connection(process.env.NEXT_PUBLIC_HELIUS_MAINNET_RPC || '', 'recent'),
-  );
+  const connection = useRef<Connection | null>(null);
   const logger = useRef(new Logger());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    connection.current = new Connection(
+      new URL(HELIUS_MAINNET_PROXY_PATH, window.location.origin).toString(),
+      'recent',
+    );
+  }, []);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && running) {
@@ -115,37 +125,39 @@ export function Stats(props: Props) {
         <NumProposals proposals={proposals} />
         <NumVoteRecords voteRecords={voteRecords} />
         <NumMembers members={members} />
-        <DataFetch
-          className="mt-10"
-          connection={connection.current}
-          logger={logger.current}
-          onComplete={() => {
-            if (wakePrevent?.current?.release) {
-              wakePrevent.current.release();
-            }
+        {connection.current ? (
+          <DataFetch
+            className="mt-10"
+            connection={connection.current}
+            logger={logger.current}
+            onComplete={() => {
+              if (wakePrevent?.current?.release) {
+                wakePrevent.current.release();
+              }
 
-            if (timer?.current) {
-              window.clearInterval(timer.current);
-            }
+              if (timer?.current) {
+                window.clearInterval(timer.current);
+              }
 
-            setRunning(false);
-          }}
-          onMembersComplete={setMembers}
-          onNFTRealms={setNFTRealms}
-          onNFTRealmsComplete={(realms) => {
-            setNFTRealms(realms);
-            setDoneFetchingNFTs(true);
-          }}
-          onProposalsComplete={setProposals}
-          onRealmsComplete={setRealms}
-          onTVLComplete={(total, byDao, byDaosAndTokens) => {
-            setTotalValue(total);
-            setValueByDao(byDao);
-            setValueByDaoAndTokens(byDaosAndTokens);
-          }}
-          onVoteRecordsComplete={setVoteRecords}
-          runCount={runCount}
-        />
+              setRunning(false);
+            }}
+            onMembersComplete={setMembers}
+            onNFTRealms={setNFTRealms}
+            onNFTRealmsComplete={(realms) => {
+              setNFTRealms(realms);
+              setDoneFetchingNFTs(true);
+            }}
+            onProposalsComplete={setProposals}
+            onRealmsComplete={setRealms}
+            onTVLComplete={(total, byDao, byDaosAndTokens) => {
+              setTotalValue(total);
+              setValueByDao(byDao);
+              setValueByDaoAndTokens(byDaosAndTokens);
+            }}
+            onVoteRecordsComplete={setVoteRecords}
+            runCount={runCount}
+          />
+        ) : null}
         <Logs className="mt-10" logger={logger.current} />
       </div>
     </article>

--- a/hub/components/HeaderTokenPrice/index.tsx
+++ b/hub/components/HeaderTokenPrice/index.tsx
@@ -3,6 +3,7 @@ import CautionIcon from '@carbon/icons-react/lib/Caution';
 import type { PublicKey } from '@solana/web3.js';
 import { pipe } from 'fp-ts/lib/function';
 
+import { getJupiterPricesByMintStrings } from '@hooks/queries/jupiterPrice';
 import { useCachedValue } from '@hub/hooks/useCachedValue';
 import cx from '@hub/lib/cx';
 import * as RE from '@hub/types/Result';
@@ -13,23 +14,19 @@ interface TokenPrice {
   price: number;
 }
 
-function useTokenPrice(symbol: string, mint: PublicKey) {
+function useTokenPrice(mint: PublicKey) {
   const mintAddress = mint.toString();
 
-  return useCachedValue<TokenPrice>(mintAddress, () =>
-    fetch(`https://lite-api.jup.ag/price/v3?ids=${mintAddress}`)
-      .then((resp) => resp.json())
-      .then((result) => {
-        const price =
-          result[mintAddress]?.usdPrice ||
-          result.data?.[mintAddress]?.price ||
-          0;
-        return {
-          direction: 'up',
-          percentChange: 0,
-          price,
-        };
-      }),
+  return useCachedValue<TokenPrice>(mintAddress, async () => {
+    const result = await getJupiterPricesByMintStrings([mintAddress]);
+    const price = result[mintAddress]?.price || 0;
+
+    return {
+      direction: 'up',
+      percentChange: 0,
+      price,
+    };
+  },
   );
 }
 
@@ -40,7 +37,7 @@ interface Props {
 }
 
 export function HeaderTokenPrice(props: Props) {
-  const tokenPrice = useTokenPrice(props.symbol, props.mint);
+  const tokenPrice = useTokenPrice(props.mint);
 
   return pipe(
     tokenPrice,

--- a/hub/components/HeaderTokenPrice/index.tsx
+++ b/hub/components/HeaderTokenPrice/index.tsx
@@ -17,10 +17,13 @@ function useTokenPrice(symbol: string, mint: PublicKey) {
   const mintAddress = mint.toString();
 
   return useCachedValue<TokenPrice>(mintAddress, () =>
-    fetch(`https://price.jup.ag/v3/price?ids=${mintAddress}`)
+    fetch(`https://lite-api.jup.ag/price/v3?ids=${mintAddress}`)
       .then((resp) => resp.json())
       .then((result) => {
-        const price = result.data[mintAddress].price || 0;
+        const price =
+          result[mintAddress]?.usdPrice ||
+          result.data?.[mintAddress]?.price ||
+          0;
         return {
           direction: 'up',
           percentChange: 0,

--- a/hub/providers/Cluster/index.tsx
+++ b/hub/providers/Cluster/index.tsx
@@ -2,11 +2,15 @@ import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { clusterApiUrl, Connection } from '@solana/web3.js';
 import { useRouter } from 'next/router';
 import { createContext, useEffect, useState } from 'react';
+import {
+  DEVNET_RPC,
+  DEVNET_WS_RPC,
+  MAINNET_RPC,
+  MAINNET_WS_RPC,
+} from '@constants/endpoints';
 
-const DEVNET_RPC_ENDPOINT =
-  process.env.DEVNET_RPC || 'https://api.dao.devnet.solana.com/';
-const MAINNET_RPC_ENDPOINT =
-  process.env.MAINNET_RPC || 'http://realms-realms-c335.mainnet.rpcpool.com';
+const DEVNET_RPC_ENDPOINT = DEVNET_RPC;
+const MAINNET_RPC_ENDPOINT = MAINNET_RPC;
 const TESTNET_RPC_ENDPOINT = 'http://127.0.0.1:8899';
 
 export enum ClusterType {
@@ -25,7 +29,10 @@ interface Cluster {
 
 export const DevnetCluster: Cluster = {
   type: ClusterType.Devnet,
-  connection: new Connection(DEVNET_RPC_ENDPOINT, 'recent'),
+  connection: new Connection(DEVNET_RPC_ENDPOINT, {
+    commitment: 'recent',
+    wsEndpoint: DEVNET_WS_RPC,
+  }),
   endpoint: clusterApiUrl('devnet'),
   network: WalletAdapterNetwork.Devnet,
   rpcEndpoint: DEVNET_RPC_ENDPOINT,
@@ -33,7 +40,10 @@ export const DevnetCluster: Cluster = {
 
 export const MainnetCluster: Cluster = {
   type: ClusterType.Mainnet,
-  connection: new Connection(MAINNET_RPC_ENDPOINT, 'recent'),
+  connection: new Connection(MAINNET_RPC_ENDPOINT, {
+    commitment: 'recent',
+    wsEndpoint: MAINNET_WS_RPC,
+  }),
   endpoint: clusterApiUrl('mainnet-beta'),
   network: WalletAdapterNetwork.Mainnet,
   rpcEndpoint: MAINNET_RPC_ENDPOINT,

--- a/next.config.js
+++ b/next.config.js
@@ -35,8 +35,6 @@ config = withTM({
       process.env.MAIN_VIEW_SHOW_MAX_TOP_TOKENS_NUM,
     DISABLE_NFTS: process.env.DISABLE_NFTS,
     REALM: process.env.REALM,
-    MAINNET_RPC: process.env.MAINNET_RPC,
-    DEVNET_RPC: process.env.DEVNET_RPC,
     DEFAULT_GOVERNANCE_PROGRAM_ID: process.env.DEFAULT_GOVERNANCE_PROGRAM_ID,
   },
   //proxy for openserum api cors

--- a/pages/api/daoProgramStatistics.api.ts
+++ b/pages/api/daoProgramStatistics.api.ts
@@ -6,9 +6,9 @@ import { getAllSplGovernanceProgramIds } from './tools/realms'
 import { withSentry } from '@sentry/nextjs'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.BACKEND_MAINNET_RPC)
-    return res.status(500).json('BACKEND_MAINNET_RPC not provided in env')
-  const conn = new Connection(process.env.BACKEND_MAINNET_RPC, 'recent')
+  if (!process.env.MAINNET_RPC)
+    return res.status(500).json('MAINNET_RPC not provided in env')
+  const conn = new Connection(process.env.MAINNET_RPC, 'recent')
 
   console.log('fetching spl-gov instances...')
   // Get all realms

--- a/pages/api/daoStatistics.api.ts
+++ b/pages/api/daoStatistics.api.ts
@@ -59,9 +59,9 @@ async function getGovernances(
 }
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.BACKEND_MAINNET_RPC)
-    return res.status(500).json('BACKEND_MAINNET_RPC not provided in env')
-  const conn = new Connection(process.env.BACKEND_MAINNET_RPC, 'recent')
+  if (!process.env.MAINNET_RPC)
+    return res.status(500).json('MAINNET_RPC not provided in env')
+  const conn = new Connection(process.env.MAINNET_RPC, 'recent')
 
   console.log('fetching spl-gov instances...')
   // Get all realms

--- a/pages/api/daoVoteStatistics.api.ts
+++ b/pages/api/daoVoteStatistics.api.ts
@@ -12,9 +12,9 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getAllSplGovernanceProgramIds } from './tools/realms'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.BACKEND_MAINNET_RPC)
-    return res.status(500).json('BACKEND_MAINNET_RPC not provided in env')
-  const conn = new Connection(process.env.BACKEND_MAINNET_RPC, 'recent')
+  if (!process.env.MAINNET_RPC)
+    return res.status(500).json('MAINNET_RPC not provided in env')
+  const conn = new Connection(process.env.MAINNET_RPC, 'recent')
 
   console.log('fetching spl-gov instances...')
   // Get all realms

--- a/pages/api/daoVoteUserStatistics.api.ts
+++ b/pages/api/daoVoteUserStatistics.api.ts
@@ -19,9 +19,9 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import mainnetList from 'public/realms/mainnet-beta.json'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.BACKEND_MAINNET_RPC)
-    return res.status(500).json('BACKEND_MAINNET_RPC not provided in env')
-  const conn = new Connection(process.env.BACKEND_MAINNET_RPC, 'recent')
+  if (!process.env.MAINNET_RPC)
+    return res.status(500).json('MAINNET_RPC not provided in env')
+  const conn = new Connection(process.env.MAINNET_RPC, 'recent')
 
   const { dao, user } = req.query
   if (!dao) {

--- a/pages/api/getDecodedMangoInstructionsFromProposal.api.ts
+++ b/pages/api/getDecodedMangoInstructionsFromProposal.api.ts
@@ -14,9 +14,9 @@ import { getClient } from '@utils/mangoV4Tools'
 import { BN, BorshInstructionCoder } from '@coral-xyz/anchor'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.BACKEND_MAINNET_RPC)
-    return res.status(500).json('BACKEND_MAINNET_RPC not provided in env')
-  const conn = new Connection(process.env.BACKEND_MAINNET_RPC, 'recent')
+  if (!process.env.MAINNET_RPC)
+    return res.status(500).json('MAINNET_RPC not provided in env')
+  const conn = new Connection(process.env.MAINNET_RPC, 'recent')
 
   const proposalPk = req.query.proposal
   if (!proposalPk) {

--- a/pages/api/helius/[network].api.ts
+++ b/pages/api/helius/[network].api.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  HELIUS_DEVNET_RPC_ENV_VAR,
+  HELIUS_MAINNET_RPC_ENV_VAR,
+  HeliusNetwork,
+} from '@utils/heliusApi'
+
+const getHeliusRpcUrl = (network: HeliusNetwork) => {
+  if (network === 'devnet') {
+    return process.env[HELIUS_DEVNET_RPC_ENV_VAR]
+  }
+
+  return process.env[HELIUS_MAINNET_RPC_ENV_VAR]
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const network = req.query.network
+  if (network !== 'mainnet' && network !== 'devnet') {
+    return res.status(400).json({ error: 'Unsupported network' })
+  }
+
+  const rpcUrl = getHeliusRpcUrl(network)
+  if (!rpcUrl) {
+    const envVar =
+      network === 'devnet'
+        ? HELIUS_DEVNET_RPC_ENV_VAR
+        : HELIUS_MAINNET_RPC_ENV_VAR
+    return res.status(500).json({ error: `${envVar} not provided in env` })
+  }
+
+  try {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(req.body),
+    })
+    const body = await response.json()
+
+    res.setHeader('Cache-Control', 'no-store')
+    return res.status(response.status).json(body)
+  } catch (error) {
+    console.error(`Error proxying Helius ${network} request:`, error)
+    return res.status(500).json({ error: 'Failed to proxy Helius request' })
+  }
+}
+
+export default handler

--- a/pages/api/jupiter/price.api.ts
+++ b/pages/api/jupiter/price.api.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  JUPITER_API_KEY_ENV_VAR,
+  JUPITER_PRICE_BATCH_LIMIT,
+} from '@utils/jupiterApi'
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const ids = (typeof req.query.ids === 'string' ? req.query.ids : '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+
+  if (ids.length === 0) {
+    return res.status(400).json({ error: 'ids query parameter is required' })
+  }
+
+  if (ids.length > JUPITER_PRICE_BATCH_LIMIT) {
+    return res.status(400).json({
+      error: `ids supports up to ${JUPITER_PRICE_BATCH_LIMIT} mints per request`,
+    })
+  }
+
+  const apiKey = process.env[JUPITER_API_KEY_ENV_VAR]
+
+  if (!apiKey) {
+    return res
+      .status(500)
+      .json({ error: `${JUPITER_API_KEY_ENV_VAR} not provided in env` })
+  }
+
+  try {
+    const url = new URL('https://api.jup.ag/price/v3')
+    url.searchParams.set('ids', ids.join(','))
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        'x-api-key': apiKey,
+      },
+    })
+    const body = await response.json()
+
+    res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate=300')
+
+    return res.status(response.status).json(body)
+  } catch (error) {
+    console.error('Error fetching Jupiter prices:', error)
+    return res.status(500).json({ error: 'Failed to fetch Jupiter prices' })
+  }
+}
+
+export default handler

--- a/pages/api/jupiter/quote.api.ts
+++ b/pages/api/jupiter/quote.api.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  JUPITER_API_KEY_ENV_VAR,
+  buildJupiterSwapUrl,
+} from '@utils/jupiterApi'
+
+const REQUIRED_QUERY_PARAMS = [
+  'inputMint',
+  'outputMint',
+  'amount',
+  'slippageBps',
+  'swapMode',
+] as const
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const params = Object.fromEntries(
+    Object.entries(req.query).flatMap(([key, value]) =>
+      typeof value === 'string' ? [[key, value]] : [],
+    ),
+  )
+
+  const missing = REQUIRED_QUERY_PARAMS.filter((key) => !params[key])
+  if (missing.length > 0) {
+    return res.status(400).json({
+      error: `Missing query params: ${missing.join(', ')}`,
+    })
+  }
+
+  const apiKey = process.env[JUPITER_API_KEY_ENV_VAR]
+
+  if (!apiKey) {
+    return res
+      .status(500)
+      .json({ error: `${JUPITER_API_KEY_ENV_VAR} not provided in env` })
+  }
+
+  try {
+    const response = await fetch(buildJupiterSwapUrl('/swap/v1/quote', params), {
+      headers: {
+        'x-api-key': apiKey,
+      },
+    })
+    const body = await response.json()
+
+    res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=60')
+
+    return res.status(response.status).json(body)
+  } catch (error) {
+    console.error('Error fetching Jupiter quote:', error)
+    return res.status(500).json({ error: 'Failed to fetch Jupiter quote' })
+  }
+}
+
+export default handler

--- a/pages/api/jupiter/tokens/tag.api.ts
+++ b/pages/api/jupiter/tokens/tag.api.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  JUPITER_API_KEY_ENV_VAR,
+  JUPITER_TOKEN_TAGS,
+  JupiterTokenTag,
+} from '@utils/jupiterApi'
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const query = typeof req.query.query === 'string' ? req.query.query : ''
+
+  if (!JUPITER_TOKEN_TAGS.includes(query as JupiterTokenTag)) {
+    return res.status(400).json({
+      error: `query must be one of: ${JUPITER_TOKEN_TAGS.join(', ')}`,
+    })
+  }
+
+  const apiKey = process.env[JUPITER_API_KEY_ENV_VAR]
+
+  if (!apiKey) {
+    return res
+      .status(500)
+      .json({ error: `${JUPITER_API_KEY_ENV_VAR} not provided in env` })
+  }
+
+  try {
+    const url = new URL('https://api.jup.ag/tokens/v2/tag')
+    url.searchParams.set('query', query)
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        'x-api-key': apiKey,
+      },
+    })
+    const body = await response.json()
+
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=3600')
+
+    return res.status(response.status).json(body)
+  } catch (error) {
+    console.error('Error fetching Jupiter tokens by tag:', error)
+    return res
+      .status(500)
+      .json({ error: 'Failed to fetch Jupiter tokens by tag' })
+  }
+}
+
+export default handler

--- a/pages/api/mangoAccountsWithDeposit.api.ts
+++ b/pages/api/mangoAccountsWithDeposit.api.ts
@@ -12,9 +12,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!mint) {
       return res.status(403).json('Please provide mint param')
     }
-    if (!process.env.BACKEND_MAINNET_RPC)
-      return res.status(500).json('BACKEND_MAINNET_RPC not provided in env')
-    const conn = new Connection(process.env.BACKEND_MAINNET_RPC, 'recent')
+    if (!process.env.MAINNET_RPC)
+      return res.status(500).json('MAINNET_RPC not provided in env')
+    const conn = new Connection(process.env.MAINNET_RPC, 'recent')
     const MAINNET_GROUP = new PublicKey(
       '78b8f4cGCwmZ9ysPFMWLaLTkkaYnUjwMJYStWe5RTSSX',
     )

--- a/pages/api/solana/[network].api.ts
+++ b/pages/api/solana/[network].api.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const getRpcEnvVar = (network: 'mainnet' | 'devnet') =>
+  network === 'devnet' ? 'DEVNET_RPC' : 'MAINNET_RPC'
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const network = req.query.network
+  if (network !== 'mainnet' && network !== 'devnet') {
+    return res.status(400).json({ error: 'Unsupported network' })
+  }
+
+  const rpcEnvVar = getRpcEnvVar(network)
+  const rpcUrl = process.env[rpcEnvVar]
+
+  if (!rpcUrl) {
+    return res.status(500).json({ error: `${rpcEnvVar} not provided in env` })
+  }
+
+  try {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(req.body),
+    })
+    const body = await response.json()
+
+    res.setHeader('Cache-Control', 'no-store')
+    return res.status(response.status).json(body)
+  } catch (error) {
+    console.error(`Error proxying Solana ${network} request:`, error)
+    return res.status(500).json({ error: 'Failed to proxy Solana request' })
+  }
+}
+
+export default handler

--- a/pages/api/vsrDeposits.api.ts
+++ b/pages/api/vsrDeposits.api.ts
@@ -8,9 +8,9 @@ import { toUiDecimals } from '@blockworks-foundation/mango-v4'
 import { VsrClient } from 'VoteStakeRegistry/sdk/client'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.BACKEND_MAINNET_RPC)
-    return res.status(500).json('BACKEND_MAINNET_RPC not provided in env')
-  const conn = new Connection(process.env.BACKEND_MAINNET_RPC, 'recent')
+  if (!process.env.MAINNET_RPC)
+    return res.status(500).json('MAINNET_RPC not provided in env')
+  const conn = new Connection(process.env.MAINNET_RPC, 'recent')
 
   const options = AnchorProvider.defaultOptions()
   const adminProvider = new AnchorProvider(

--- a/utils/Mango/listingTools.ts
+++ b/utils/Mango/listingTools.ts
@@ -29,6 +29,7 @@ import {
 } from '@solana/web3.js'
 import SwitchboardProgram from '@switchboard-xyz/sbv2-lite'
 import { notify } from '@utils/notifications'
+import { fetchJupiterQuoteJson } from '@utils/jupiterApi'
 import Big from 'big.js'
 import { secondsToHours } from 'date-fns'
 
@@ -264,23 +265,16 @@ const fetchJupiterRoutes = async (
 ) => {
   {
     try {
-      const paramsString = new URLSearchParams({
+      const params = {
         inputMint: inputMint.toString(),
         outputMint: outputMint.toString(),
         amount: amount.toString(),
         slippageBps: Math.ceil(slippage * 100).toString(),
         feeBps: feeBps.toString(),
         swapMode,
-      }).toString()
+      }
 
-      const jupiterSwapBaseUrl =
-        process.env.NEXT_PUBLIC_JUPTER_SWAP_API_ENDPOINT ||
-        'https://quote-api.jup.ag/v6'
-      const response = await fetch(
-        `${jupiterSwapBaseUrl}/quote?${paramsString}`,
-      )
-
-      const res = await response.json()
+      const res = await fetchJupiterQuoteJson<RouteInfo | null>(params)
       return {
         bestRoute: (res ? res : null) as RouteInfo | null,
       }

--- a/utils/connection.ts
+++ b/utils/connection.ts
@@ -1,7 +1,12 @@
 import type { EndpointTypes } from '@models/types'
 import { Connection } from '@solana/web3.js'
 import type { EndpointInfo } from '../@types/types'
-import { DEVNET_RPC, MAINNET_RPC } from '@constants/endpoints'
+import {
+  DEVNET_RPC,
+  DEVNET_WS_RPC,
+  MAINNET_RPC,
+  MAINNET_WS_RPC,
+} from '@constants/endpoints'
 
 export const BACKUP_CONNECTIONS = [
   new Connection(`https://rpc.mngo.cloud/rlmk0lo5odee/`, 'recent'),
@@ -32,9 +37,14 @@ export interface ConnectionContext {
 
 export function getConnectionContext(cluster: string): ConnectionContext {
   const ENDPOINT = ENDPOINTS.find((e) => e.name === cluster) || ENDPOINTS[0]
+  const wsEndpoint =
+    ENDPOINT!.name === 'devnet' ? DEVNET_WS_RPC : MAINNET_WS_RPC
   return {
     cluster: ENDPOINT!.name as EndpointTypes,
-    current: new Connection(ENDPOINT!.url, 'recent'),
+    current: new Connection(ENDPOINT!.url, {
+      commitment: 'recent',
+      wsEndpoint,
+    }),
     endpoint: ENDPOINT!.url,
   }
 }

--- a/utils/heliusApi.ts
+++ b/utils/heliusApi.ts
@@ -1,0 +1,9 @@
+export const HELIUS_MAINNET_RPC_ENV_VAR = 'HELIUS_MAINNET_RPC'
+export const HELIUS_DEVNET_RPC_ENV_VAR = 'HELIUS_DEVNET_RPC'
+export const HELIUS_MAINNET_PROXY_PATH = '/api/helius/mainnet'
+export const HELIUS_DEVNET_PROXY_PATH = '/api/helius/devnet'
+
+export type HeliusNetwork = 'mainnet' | 'devnet'
+
+export const getHeliusProxyPath = (network: HeliusNetwork) =>
+  network === 'devnet' ? HELIUS_DEVNET_PROXY_PATH : HELIUS_MAINNET_PROXY_PATH

--- a/utils/jupiterApi.ts
+++ b/utils/jupiterApi.ts
@@ -1,0 +1,79 @@
+const JUPITER_API_BASE_URL = 'https://api.jup.ag'
+
+export const JUPITER_API_KEY_ENV_VAR = 'JUPITER_API_KEY'
+export const JUPITER_PRICE_BATCH_LIMIT = 50
+export const JUPITER_PRICE_PROXY_PATH = '/api/jupiter/price'
+export const JUPITER_TOKENS_TAG_PROXY_PATH = '/api/jupiter/tokens/tag'
+export const JUPITER_TOKEN_TAGS = ['verified', 'lst'] as const
+
+export type JupiterTokenTag = (typeof JUPITER_TOKEN_TAGS)[number]
+
+const isServer = () => typeof window === 'undefined'
+
+const buildProxyUrl = (pathname: string, params: Record<string, string>) => {
+  const searchParams = new URLSearchParams(params)
+  return `${pathname}?${searchParams.toString()}`
+}
+
+const buildJupiterUrl = (pathname: string, params: Record<string, string>) => {
+  const url = new URL(pathname, JUPITER_API_BASE_URL)
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value)
+  })
+  return url.toString()
+}
+
+const getServerHeaders = (): HeadersInit => {
+  const apiKey = process.env[JUPITER_API_KEY_ENV_VAR]
+
+  if (!apiKey) {
+    throw new Error(`${JUPITER_API_KEY_ENV_VAR} is not configured`)
+  }
+
+  return {
+    'x-api-key': apiKey,
+  }
+}
+
+const fetchJupiterJson = async <T>({
+  pathname,
+  proxyPath,
+  params,
+}: {
+  pathname: string
+  proxyPath: string
+  params: Record<string, string>
+}): Promise<T> => {
+  const response = await fetch(
+    isServer()
+      ? buildJupiterUrl(pathname, params)
+      : buildProxyUrl(proxyPath, params),
+    {
+      headers: isServer() ? getServerHeaders() : undefined,
+    },
+  )
+
+  if (!response.ok) {
+    throw new Error(`Jupiter request failed with status ${response.status}`)
+  }
+
+  return response.json() as Promise<T>
+}
+
+export const fetchJupiterPriceJson = async <T>(ids: string[]) =>
+  fetchJupiterJson<T>({
+    pathname: '/price/v3',
+    proxyPath: JUPITER_PRICE_PROXY_PATH,
+    params: {
+      ids: ids.join(','),
+    },
+  })
+
+export const fetchJupiterTokensByTagJson = async <T>(query: JupiterTokenTag) =>
+  fetchJupiterJson<T>({
+    pathname: '/tokens/v2/tag',
+    proxyPath: JUPITER_TOKENS_TAG_PROXY_PATH,
+    params: {
+      query,
+    },
+  })

--- a/utils/jupiterApi.ts
+++ b/utils/jupiterApi.ts
@@ -1,8 +1,10 @@
 const JUPITER_API_BASE_URL = 'https://api.jup.ag'
 
 export const JUPITER_API_KEY_ENV_VAR = 'JUPITER_API_KEY'
+export const JUPITER_SWAP_API_BASE_URL_ENV_VAR = 'JUPITER_SWAP_API_BASE_URL'
 export const JUPITER_PRICE_BATCH_LIMIT = 50
 export const JUPITER_PRICE_PROXY_PATH = '/api/jupiter/price'
+export const JUPITER_QUOTE_PROXY_PATH = '/api/jupiter/quote'
 export const JUPITER_TOKENS_TAG_PROXY_PATH = '/api/jupiter/tokens/tag'
 export const JUPITER_TOKEN_TAGS = ['verified', 'lst'] as const
 
@@ -17,6 +19,19 @@ const buildProxyUrl = (pathname: string, params: Record<string, string>) => {
 
 const buildJupiterUrl = (pathname: string, params: Record<string, string>) => {
   const url = new URL(pathname, JUPITER_API_BASE_URL)
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value)
+  })
+  return url.toString()
+}
+
+export const buildJupiterSwapUrl = (
+  pathname: string,
+  params: Record<string, string>,
+) => {
+  const baseUrl =
+    process.env[JUPITER_SWAP_API_BASE_URL_ENV_VAR] || JUPITER_API_BASE_URL
+  const url = new URL(pathname, baseUrl)
   Object.entries(params).forEach(([key, value]) => {
     url.searchParams.set(key, value)
   })
@@ -76,4 +91,13 @@ export const fetchJupiterTokensByTagJson = async <T>(query: JupiterTokenTag) =>
     params: {
       query,
     },
+  })
+
+export const fetchJupiterQuoteJson = async <T>(
+  params: Record<string, string>,
+) =>
+  fetchJupiterJson<T>({
+    pathname: '/swap/v1/quote',
+    proxyPath: JUPITER_QUOTE_PROXY_PATH,
+    params,
   })

--- a/utils/services/tokenPrice.tsx
+++ b/utils/services/tokenPrice.tsx
@@ -10,12 +10,41 @@ import { USDC_MINT } from '@blockworks-foundation/mango-v4'
 import { useLocalStorage } from '@hooks/useLocalStorage'
 import { getJupiterPricesByMintStrings } from '@hooks/queries/jupiterPrice'
 
-const tokenListUrl = 'https://tokens.jup.ag/tokens?tags=verified,lst'
+const tokenListUrls = [
+  'https://lite-api.jup.ag/tokens/v2/tag?query=verified',
+  'https://lite-api.jup.ag/tokens/v2/tag?query=lst',
+]
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24 // 24 hours
 const PRICE_STORAGE_KEY = 'tokenPrices'
 const PRICE_CACHE_TTL_MS = 1000 * 60 * 5 // 5 minutes TTL
 
 export type TokenInfoJupiter = TokenInfo
+
+type JupiterToken = {
+  id: string
+  name: string
+  symbol: string
+  decimals: number
+  icon?: string
+  tags?: string[]
+  extensions?: TokenInfo['extensions']
+}
+
+const normalizeToken = (token: TokenInfo | JupiterToken): TokenInfo => ({
+  chainId: 'chainId' in token ? token.chainId : 101,
+  address: 'address' in token ? token.address : token.id,
+  name: token.name,
+  decimals: token.decimals,
+  symbol: token.symbol,
+  logoURI: 'logoURI' in token ? token.logoURI : token.icon,
+  tags: token.tags,
+  extensions: token.extensions,
+})
+
+const mergeTokenLists = (lists: TokenInfo[][]) =>
+  Array.from(
+    new Map(lists.flat().map((token) => [token.address, token])).values(),
+  )
 
 class TokenPriceService {
   _tokenList: TokenInfo[]
@@ -32,8 +61,14 @@ class TokenPriceService {
 
   async fetchSolanaTokenList() {
     try {
-      const tokens = await axios.get(tokenListUrl)
-      const tokenList = tokens.data as TokenInfo[]
+      const responses = await Promise.all(
+        tokenListUrls.map((url) => axios.get(url)),
+      )
+      const tokenList = mergeTokenLists(
+        responses.map((response) =>
+          (response.data as (TokenInfo | JupiterToken)[]).map(normalizeToken),
+        ),
+      )
       if (tokenList && tokenList.length) {
         this._tokenList = tokenList.map((token) => {
           const override = overrides[token.address]
@@ -63,8 +98,14 @@ class TokenPriceService {
 
     try {
       if (!tokenListRaw || !ttl || Date.now() > Number(ttl)) {
-        const response = await axios.get(tokenListUrl)
-        const tokens = response.data as TokenInfo[]
+        const responses = await Promise.all(
+          tokenListUrls.map((url) => axios.get(url)),
+        )
+        const tokens = mergeTokenLists(
+          responses.map((response) =>
+            (response.data as (TokenInfo | JupiterToken)[]).map(normalizeToken),
+          ),
+        )
 
         if (tokens && tokens.length) {
           tokenList = tokens.map((token) => {
@@ -329,28 +370,6 @@ class TokenPriceService {
 
     // logo not found so we return no data.
     return undefined
-    // Get the token data from JUP's api
-    // try {
-    //   const requestURL = `https://tokens.jup.ag/token/${mintAddress}`
-    //   const response = await axios.get(requestURL)
-    //   if (response.data) {
-    //     // Remove decimals and add chainId to match the TokenInfoWithoutDecimals struct
-    //     const { decimals, ...tokenInfoWithoutDecimals } = response.data
-
-    //     const finalTokenInfo = {
-    //       ...tokenInfoWithoutDecimals,
-    //       chainId: 101,
-    //     }
-    //     // Add to unverified token cache
-    //     this._unverifiedTokenCache[mintAddress] = finalTokenInfo
-    //     return finalTokenInfo
-    //   } else {
-    //     return undefined
-    //   }
-    // } catch {
-    //   console.error(`Metadata retrieving failed for ${mintAddress}`)
-    //   return undefined
-    // }
   }
   catch(e) {
     console.error(e)

--- a/utils/services/tokenPrice.tsx
+++ b/utils/services/tokenPrice.tsx
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { mergeDeepRight } from 'ramda'
 
 import { notify } from '@utils/notifications'
@@ -9,11 +8,12 @@ import { chunks } from '@utils/helpers'
 import { USDC_MINT } from '@blockworks-foundation/mango-v4'
 import { useLocalStorage } from '@hooks/useLocalStorage'
 import { getJupiterPricesByMintStrings } from '@hooks/queries/jupiterPrice'
+import {
+  fetchJupiterTokensByTagJson,
+  JupiterTokenTag,
+} from '@utils/jupiterApi'
 
-const tokenListUrls = [
-  'https://lite-api.jup.ag/tokens/v2/tag?query=verified',
-  'https://lite-api.jup.ag/tokens/v2/tag?query=lst',
-]
+const tokenListTags: JupiterTokenTag[] = ['verified', 'lst']
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24 // 24 hours
 const PRICE_STORAGE_KEY = 'tokenPrices'
 const PRICE_CACHE_TTL_MS = 1000 * 60 * 5 // 5 minutes TTL
@@ -30,13 +30,16 @@ type JupiterToken = {
   extensions?: TokenInfo['extensions']
 }
 
+const isTokenInfo = (token: TokenInfo | JupiterToken): token is TokenInfo =>
+  'address' in token
+
 const normalizeToken = (token: TokenInfo | JupiterToken): TokenInfo => ({
   chainId: 'chainId' in token ? token.chainId : 101,
-  address: 'address' in token ? token.address : token.id,
+  address: isTokenInfo(token) ? token.address : token.id,
   name: token.name,
   decimals: token.decimals,
   symbol: token.symbol,
-  logoURI: 'logoURI' in token ? token.logoURI : token.icon,
+  logoURI: isTokenInfo(token) ? token.logoURI : token.icon || undefined,
   tags: token.tags,
   extensions: token.extensions,
 })
@@ -62,12 +65,12 @@ class TokenPriceService {
   async fetchSolanaTokenList() {
     try {
       const responses = await Promise.all(
-        tokenListUrls.map((url) => axios.get(url)),
+        tokenListTags.map((tag) =>
+          fetchJupiterTokensByTagJson<(TokenInfo | JupiterToken)[]>(tag),
+        ),
       )
       const tokenList = mergeTokenLists(
-        responses.map((response) =>
-          (response.data as (TokenInfo | JupiterToken)[]).map(normalizeToken),
-        ),
+        responses.map((response) => response.map(normalizeToken)),
       )
       if (tokenList && tokenList.length) {
         this._tokenList = tokenList.map((token) => {
@@ -99,12 +102,12 @@ class TokenPriceService {
     try {
       if (!tokenListRaw || !ttl || Date.now() > Number(ttl)) {
         const responses = await Promise.all(
-          tokenListUrls.map((url) => axios.get(url)),
+          tokenListTags.map((tag) =>
+            fetchJupiterTokensByTagJson<(TokenInfo | JupiterToken)[]>(tag),
+          ),
         )
         const tokens = mergeTokenLists(
-          responses.map((response) =>
-            (response.data as (TokenInfo | JupiterToken)[]).map(normalizeToken),
-          ),
+          responses.map((response) => response.map(normalizeToken)),
         )
 
         if (tokens && tokens.length) {

--- a/utils/solanaRpc.ts
+++ b/utils/solanaRpc.ts
@@ -1,0 +1,35 @@
+export const SOLANA_MAINNET_PROXY_PATH = '/api/solana/mainnet'
+export const SOLANA_DEVNET_PROXY_PATH = '/api/solana/devnet'
+
+type SolanaNetwork = 'mainnet' | 'devnet'
+
+const PUBLIC_HTTP_ENDPOINTS: Record<SolanaNetwork, string> = {
+  mainnet: 'https://api.mainnet-beta.solana.com',
+  devnet: 'https://api.devnet.solana.com',
+}
+
+const PUBLIC_WS_ENDPOINTS: Record<SolanaNetwork, string> = {
+  mainnet: 'wss://api.mainnet-beta.solana.com',
+  devnet: 'wss://api.devnet.solana.com',
+}
+
+const SERVER_ENV_VARS: Record<SolanaNetwork, string> = {
+  mainnet: 'MAINNET_RPC',
+  devnet: 'DEVNET_RPC',
+}
+
+const PROXY_PATHS: Record<SolanaNetwork, string> = {
+  mainnet: SOLANA_MAINNET_PROXY_PATH,
+  devnet: SOLANA_DEVNET_PROXY_PATH,
+}
+
+export const getSolanaRpcEndpoint = (network: SolanaNetwork) => {
+  if (typeof window !== 'undefined') {
+    return new URL(PROXY_PATHS[network], window.location.origin).toString()
+  }
+
+  return process.env[SERVER_ENV_VARS[network]] || PUBLIC_HTTP_ENDPOINTS[network]
+}
+
+export const getSolanaWsEndpoint = (network: SolanaNetwork) =>
+  PUBLIC_WS_ENDPOINTS[network]


### PR DESCRIPTION
Remove the hardcoded Helius API key from frontend RPC defaults and document the public env override variables.

Update Jupiter token and price fetches to current lite-api endpoints, adapting the V3 price and token response shapes to the app's existing internal types.